### PR TITLE
Add: num kinds option allowKansuji and allowFigure

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ Via `.textlintrc`(Recommended)
 ```json
 {
     "rules": {
-        "kansuji-number": true
+        "kansuji-number": {
+            "allowKansuji": false
+            // "allowFigure": false
+        }
     }
 }
 ```
@@ -27,6 +30,11 @@ Via CLI
 ```
 textlint --rule kansuji-number README.md
 ```
+
+### Options
+
+- allowKansuji: `false` で漢数字を利用しているかチェックします
+- allowFigures: `false` でアラビア数字を利用しているかチェックします
 
 ### Build
 
@@ -38,7 +46,7 @@ You can write ES2015+ source codes in `src/` folder.
 ### Tests
 
 Run test code in `test` folder.
-Test textlint rule by [textlint-tester](https://github.com/textlint/textlint-tester).
+Test textlint rule by [textlint-tester](https://github.com/textlint/textlint/tree/master/packages/textlint-tester).
 
     npm test
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,31 @@ textlint --rule kansuji-number README.md
 ### Options
 
 - allowKansuji: `false` で漢数字を利用しているかチェックします。デフォルトで `false` です。
-- allowFigures: `false` でアラビア数字を利用しているかチェックします
+- allowFigure: `false` でアラビア数字を利用しているかチェックします
+
+#### Examples
+
+漢数字がNG
+```
+{ "allowKansuji": false, "allowFigure": true}
+
+// OK
+アラビア数字の10億円。
+// NG
+漢数字の十億円。
+```
+
+アラビア数字がNG
+
+```
+{ "allowKansuji": true, "allowFigure": false}
+
+// OK
+漢数字の十億円。
+// NG
+アラビア数字の10億円。
+```
+
 
 ### Build
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Via `.textlintrc`(Recommended)
 {
     "rules": {
         "kansuji-number": {
-            "allowKansuji": false
+            "allowKansuji": false  // default to false
             // "allowFigure": false
         }
     }
@@ -33,7 +33,7 @@ textlint --rule kansuji-number README.md
 
 ### Options
 
-- allowKansuji: `false` で漢数字を利用しているかチェックします
+- allowKansuji: `false` で漢数字を利用しているかチェックします。デフォルトで `false` です。
 - allowFigures: `false` でアラビア数字を利用しているかチェックします
 
 ### Build

--- a/src/index.js
+++ b/src/index.js
@@ -1,25 +1,39 @@
-import { findKanjiNumbers } from '@geolonia/japanese-numeral'
+import { findKanjiNumbers, kanji2number } from '@geolonia/japanese-numeral'
+
+const defaultOptions = {
+    prohibitKansuji: false,
+    prohibitFigure: false
+};
+
+const regexKansuji = /[一二三四五六七八九十]/g;
+const regexFigures = /\d/g;
 
 export default function(context, options = {}) {
     const {Syntax, RuleError, report, getSource} = context;
+    const prohibitKansuji = options.prohibitKansuji ? options.prohibitKansuji : defaultOptions.prohibitKansuji;
+    const prohibitFigure = options.prohibitFigure ? options.prohibitFigure : defaultOptions.prohibitFigure;
     return {
         [Syntax.Str](node){ // "Str" node
             const text = getSource(node); // Get text
             const numbers = findKanjiNumbers(text);
 
-            function getRuleError(word){
+            function getRuleError(word, message="Found bugs."){
                 const re = new RegExp(word);
                 const indexOfBugs = re.exec(text).index;
-                const ruleError = new RuleError("Found bugs.", {
+                const ruleError = new RuleError(message, {
                     index: indexOfBugs // padding of index
                 });
                 return ruleError
             };
             for(const num of numbers){
                 // judge number
-                const matchNumCount = /^\d{5,}[万億兆]$/.test(num);
-                if(matchNumCount === true){
-                    report(node, getRuleError(num));
+                const kansujiIndex = num.search(regexKansuji);
+                const figureIndex = num.search(regexFigures);
+                if(prohibitKansuji===true&kansujiIndex>=0&kanji2number(num)>10){
+                    report(node, getRuleError(num, "漢数字が含まれています"));
+                }
+                else if(prohibitFigure===true&figureIndex>=0){
+                    report(node, getRuleError(num, "アラビア数字が含まれています"));
                 }
             }
         }      

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,17 @@
 import { findKanjiNumbers, kanji2number } from '@geolonia/japanese-numeral'
 
 const defaultOptions = {
-    prohibitKansuji: false,
-    prohibitFigure: false
+    allowKansuji: true,
+    allowFigure: true
 };
 
 const regexKansuji = /[一二三四五六七八九十]/g;
-const regexFigures = /\d/g;
+const regexFigure = /\d/g;
 
 export default function(context, options = {}) {
     const {Syntax, RuleError, report, getSource} = context;
-    const prohibitKansuji = options.prohibitKansuji ? options.prohibitKansuji : defaultOptions.prohibitKansuji;
-    const prohibitFigure = options.prohibitFigure ? options.prohibitFigure : defaultOptions.prohibitFigure;
+    const allowKansuji = options.allowKansuji === false ? options.allowKansuji : defaultOptions.allowKansuji;
+    const allowFigure = options.allowFigure === false ? options.allowFigure : defaultOptions.allowFigure;
     return {
         [Syntax.Str](node){ // "Str" node
             const text = getSource(node); // Get text
@@ -28,11 +28,11 @@ export default function(context, options = {}) {
             for(const num of numbers){
                 // judge number
                 const kansujiIndex = num.search(regexKansuji);
-                const figureIndex = num.search(regexFigures);
-                if(prohibitKansuji===true&kansujiIndex>=0&kanji2number(num)>10){
+                const figureIndex = num.search(regexFigure);
+                if(allowKansuji===false&kansujiIndex>=0&kanji2number(num)>10){
                     report(node, getRuleError(num, "漢数字が含まれています"));
                 }
-                else if(prohibitFigure===true&figureIndex>=0){
+                else if(allowFigure===false&figureIndex>=0){
                     report(node, getRuleError(num, "アラビア数字が含まれています"));
                 }
             }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import { findKanjiNumbers, kanji2number } from '@geolonia/japanese-numeral'
 
 const defaultOptions = {
-    allowKansuji: true,
+    allowKansuji: false,
     allowFigure: true
 };
 
@@ -10,8 +10,8 @@ const regexFigure = /\d/g;
 
 export default function(context, options = {}) {
     const {Syntax, RuleError, report, getSource} = context;
-    const allowKansuji = options.allowKansuji === false ? options.allowKansuji : defaultOptions.allowKansuji;
-    const allowFigure = options.allowFigure === false ? options.allowFigure : defaultOptions.allowFigure;
+    const allowKansuji = "allowKansuji" in options ? options.allowKansuji : defaultOptions.allowKansuji;
+    const allowFigure = "allowFigure" in options ? options.allowFigure : defaultOptions.allowFigure;
     return {
         [Syntax.Str](node){ // "Str" node
             const text = getSource(node); // Get text

--- a/src/index.js
+++ b/src/index.js
@@ -30,10 +30,10 @@ export default function(context, options = {}) {
                 const kansujiIndex = num.search(regexKansuji);
                 const figureIndex = num.search(regexFigure);
                 if(allowKansuji===false&kansujiIndex>=0&kanji2number(num)>10){
-                    report(node, getRuleError(num, "漢数字が含まれています"));
+                    report(node, getRuleError(num, `漢数字が含まれています: ${num}`));
                 }
                 else if(allowFigure===false&figureIndex>=0){
-                    report(node, getRuleError(num, "アラビア数字が含まれています"));
+                    report(node, getRuleError(num, `アラビア数字が含まれています: ${num}`));
                 }
             }
         }      

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -11,30 +11,56 @@ tester.run("rule", rule, {
         "1200000",
         "漢数字を含む1億円。",
         "漢数字を含む十二億円。",
+        {
+            text: "一期一会の出会い。二人乗り自転車。",
+            options: {
+                "prohibitKansuji": true,
+            },
+
+        }
     ],
     invalid: [
         // single match
         {
             text: "合計で10000億円になる。",
+            options: {
+                "prohibitFigure": true,
+            },
             errors: [
                 {
-                    message: "Found bugs.",
+                    message: "アラビア数字が含まれています",
                     line: 1,
                     column: 4
+                }
+            ]
+        },
+        {
+            text: "漢数字の十億円。",
+            options: {
+                "prohibitKansuji": true,
+            },
+            errors: [
+                {
+                    message: "漢数字が含まれています",
+                    line: 1,
+                    column: 5
                 }
             ]
         },
         // multiple match
         {
             text: `70000兆。\n\n数字の80000万。`,
+            options: {
+                "prohibitFigure": true,
+            },
             errors: [
                 {
-                    message: "Found bugs.",
+                    message: "アラビア数字が含まれています",
                     line: 1,
                     column: 1
                 },
                 {
-                    message: "Found bugs.",
+                    message: "アラビア数字が含まれています",
                     line: 3,
                     column: 4
                 }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -28,7 +28,7 @@ tester.run("rule", rule, {
             },
             errors: [
                 {
-                    message: "アラビア数字が含まれています",
+                    message: "アラビア数字が含まれています: 10000億",
                     line: 1,
                     column: 4
                 }
@@ -41,7 +41,7 @@ tester.run("rule", rule, {
             },
             errors: [
                 {
-                    message: "漢数字が含まれています",
+                    message: "漢数字が含まれています: 十億",
                     line: 1,
                     column: 5
                 }
@@ -56,12 +56,12 @@ tester.run("rule", rule, {
             },
             errors: [
                 {
-                    message: "アラビア数字が含まれています",
+                    message: "アラビア数字が含まれています: 70000兆",
                     line: 1,
                     column: 1
                 },
                 {
-                    message: "アラビア数字が含まれています",
+                    message: "アラビア数字が含まれています: 80000万",
                     line: 3,
                     column: 4
                 }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -9,8 +9,8 @@ tester.run("rule", rule, {
         // no problem
         "text",
         "1200000",
-        "漢数字を含む1億円。",
-        "漢数字を含む十二億円。",
+        "漢数字を含まない1億円。",
+        // "漢数字を含む十二億円。",
         {
             text: "一期一会の出会い。二人乗り自転車。",
             options: {
@@ -49,8 +49,9 @@ tester.run("rule", rule, {
         },
         // multiple match
         {
-            text: `70000兆。\n\n数字の80000万。`,
+            text: `70000兆。\n\n数字の80000万。\n漢数字を含む十二億円。`,
             options: {
+                "allowKansuji": true,
                 "allowFigure": false,
             },
             errors: [

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -14,7 +14,7 @@ tester.run("rule", rule, {
         {
             text: "一期一会の出会い。二人乗り自転車。",
             options: {
-                "prohibitKansuji": true,
+                "allowKansuji": false,
             },
 
         }
@@ -24,7 +24,7 @@ tester.run("rule", rule, {
         {
             text: "合計で10000億円になる。",
             options: {
-                "prohibitFigure": true,
+                "allowFigure": false,
             },
             errors: [
                 {
@@ -37,7 +37,7 @@ tester.run("rule", rule, {
         {
             text: "漢数字の十億円。",
             options: {
-                "prohibitKansuji": true,
+                "allowKansuji": false,
             },
             errors: [
                 {
@@ -51,7 +51,7 @@ tester.run("rule", rule, {
         {
             text: `70000兆。\n\n数字の80000万。`,
             options: {
-                "prohibitFigure": true,
+                "allowFigure": false,
             },
             errors: [
                 {


### PR DESCRIPTION
#2 

## todo 

- [x] 漢数字混じりの表現、アラビア数字混じりの表現を利用しているかチェックする options を追加
   - allowKansuji
   - allowFigure
- [x] message にチェック対象の単語を表示
- [x] README に具体例を追加

## memo
- https://github.com/geolonia/japanese-numeral の `findKanjiNumbers` は大数 (千万億 etc.) が混ざっていないとアラビアを探せない
   - e.g. 1億 は抽出できるが 10000000はできない
- future work: 漢数字を含む熟語をホワイトリストとして扱う